### PR TITLE
feat: add generated cloud tasks IAM module

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-terraform 1.3.6
-terramate 0.2.17
-tflint 0.44.1
-pre-commit 3.2.1
+terraform 1.5.7
+terramate 0.4.2
+tflint 0.48.0
+pre-commit 3.4.0

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ secure, and production-grade cloud infrastructure.
 - [google_dns_managed_zone_iam](modules/google/google_dns_managed_zone_iam)
 - [google_artifact_registry_repository_iam](modules/google/google_artifact_registry_repository_iam)
 - [google_cloud_run_service_iam](modules/google/google_cloud_run_service_iam)
+- [google_cloud_tasks_queue_iam](modules/google/google_cloud_tasks_queue_iam)
 
 ## Usage - How to Generate New IAM Modules
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -46,6 +46,7 @@ section {
       - [google_dns_managed_zone_iam](modules/google/google_dns_managed_zone_iam)
       - [google_artifact_registry_repository_iam](modules/google/google_artifact_registry_repository_iam)
       - [google_cloud_run_service_iam](modules/google/google_cloud_run_service_iam)
+      - [google_cloud_tasks_queue_iam](modules/google/google_cloud_tasks_queue_iam)
     EOT
   }
 

--- a/modules/google/google_cloud_tasks_queue_iam/README.md
+++ b/modules/google/google_cloud_tasks_queue_iam/README.md
@@ -1,0 +1,271 @@
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/851a473f65dd7d857a9311ca255c6e2763c72afe/mineiros-logo.svg" width="400"/>](https://mineiros.io/?ref=terraform-google-iam)
+
+[![Build Status](https://github.com/mineiros-io/terraform-google-iam/workflows/Tests/badge.svg)](https://github.com/mineiros-io/terraform-google-iam/actions)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/mineiros-io/terraform-google-iam.svg?label=latest&sort=semver)](https://github.com/mineiros-io/terraform-google-iam/releases)
+[![Terraform Version](https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform)](https://github.com/hashicorp/terraform/releases)
+[![Google Provider Version](https://img.shields.io/badge/google-4-1A73E8.svg?logo=terraform)](https://github.com/terraform-providers/terraform-provider-google/releases)
+[![Join Discord](https://img.shields.io/badge/Discord-Terramate-7289d9.svg?logo=discord)](https://terramate.io/discord)
+
+# Google Cloud Tasks IAM Terraform Module
+
+A [Terraform](https://www.terraform.io) module to create a [Google Cloud Tasks IAM](https://cloud.google.com/tasks/docs/reference-access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
+
+**_This module supports Terraform version 1
+and is compatible with the Terraform Google Provider version 4._**
+
+This module is part of our Infrastructure as Code (IaC) framework
+that enables our users and customers to easily deploy and manage reusable,
+secure, and production-grade cloud infrastructure.
+
+
+- [Module Features](#module-features)
+- [Getting Started](#getting-started)
+- [Module Argument Reference](#module-argument-reference)
+  - [Top-level Arguments](#top-level-arguments)
+    - [Main Resource Configuration](#main-resource-configuration)
+    - [Module Configuration](#module-configuration)
+- [Module Outputs](#module-outputs)
+- [External Documentation](#external-documentation)
+  - [Google Documentation](#google-documentation)
+  - [Terraform Google Provider Documentation:](#terraform-google-provider-documentation)
+- [Module Versioning](#module-versioning)
+  - [Backward compatibility in `0.0.z` and `0.y.z` version](#backward-compatibility-in-00z-and-0yz-version)
+- [About Mineiros](#about-mineiros)
+- [Reporting Issues](#reporting-issues)
+- [Contributing](#contributing)
+- [Makefile Targets](#makefile-targets)
+- [License](#license)
+
+## Module Features
+
+This module implements the following Terraform resources:
+
+- `google_cloud_tasks_queue_iam_binding`
+- `google_cloud_tasks_queue_iam_member`
+- `google_cloud_tasks_queue_iam_policy`
+
+## Getting Started
+
+Most common usage of the module:
+
+```hcl
+module "google_cloud_tasks_queue_iam" {
+  source = "github.com/mineiros-io/terraform-google-iam//modules/google/google_cloud_tasks_queue_iam?ref=v0.1.2"
+
+  name  = google_cloud_tasks_queue.default.name
+  location = google_cloud_tasks_queue.default.location
+  role     = "roles/cloudtasks.taskRunner"
+  members  = ["user:admin@example.com"]
+}
+```
+
+## Module Argument Reference
+
+See [variables.tf] for details.
+
+### Top-level Arguments
+
+#### Main Resource Configuration
+
+- [**`name`**](#var-name): *(**Required** `string`)*<a name="var-name"></a>
+
+  Name of Cloud Tasks Queue the IAM is applied to.
+
+- [**`location`**](#var-location): *(**Required** `string`)*<a name="var-location"></a>
+
+  The location used to find the parent resource to bind the IAM policy to
+
+- [**`members`**](#var-members): *(Optional `set(string)`)*<a name="var-members"></a>
+
+  Identities that will be granted the privilege in role. Each entry can have one of the following values:
+  `allUsers`, `allAuthenticatedUsers`, `user:{emailid}`, `serviceAccount:{emailid}`, `group:{emailid}`, `domain:{domain}`, `projectOwner:{projectid}`, `projectEditor:{projectid}`, `projectViewer:{projectid}`, `computed:{identifier}`.
+
+  Default is `[]`.
+
+- [**`computed_members_map`**](#var-computed_members_map): *(Optional `map(string)`)*<a name="var-computed_members_map"></a>
+
+  A map of members to replace in 'var.members' or in members of 'policy_bindings' to handle terraform computed values.
+
+  Default is `{}`.
+
+- [**`role`**](#var-role): *(Optional `string`)*<a name="var-role"></a>
+
+  The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`. Omit if `policy_bindings` is set.
+
+- [**`project`**](#var-project): *(Optional `string`)*<a name="var-project"></a>
+
+  The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used.
+
+- [**`authoritative`**](#var-authoritative): *(Optional `bool`)*<a name="var-authoritative"></a>
+
+  Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role.
+
+  Default is `true`.
+
+- [**`policy_bindings`**](#var-policy_bindings): *(Optional `list(policy_binding)`)*<a name="var-policy_bindings"></a>
+
+  A list of IAM policy bindings. Cannot be used at the same time as `role`.
+
+  Example:
+
+  ```hcl
+  policy_bindings = [{
+    role    = "roles/cloudtasks.taskRunner"
+    members = ["user:admin@example.com"]
+  }]
+  ```
+
+  Each `policy_binding` object in the list accepts the following attributes:
+
+  - [**`role`**](#attr-policy_bindings-role): *(**Required** `string`)*<a name="attr-policy_bindings-role"></a>
+
+    The role that should be applied.
+
+  - [**`members`**](#attr-policy_bindings-members): *(Optional `set(string)`)*<a name="attr-policy_bindings-members"></a>
+
+    Identities that will be granted the privilege in `role`.
+
+    Default is `var.members`.
+
+  - [**`condition`**](#attr-policy_bindings-condition): *(Optional `object(condition)`)*<a name="attr-policy_bindings-condition"></a>
+
+    An IAM Condition for a given binding.
+
+    Example:
+
+    ```hcl
+    condition = {
+      expression = "request.time < timestamp(\"2024-01-01T00:00:00Z\")"
+      title      = "expires_after_2023_12_31"
+    }
+    ```
+
+    The `condition` object accepts the following attributes:
+
+    - [**`expression`**](#attr-policy_bindings-condition-expression): *(**Required** `string`)*<a name="attr-policy_bindings-condition-expression"></a>
+
+      Textual representation of an expression in Common Expression Language syntax.
+
+    - [**`title`**](#attr-policy_bindings-condition-title): *(**Required** `string`)*<a name="attr-policy_bindings-condition-title"></a>
+
+      A title for the expression, i.e. a short string describing its purpose.
+
+    - [**`description`**](#attr-policy_bindings-condition-description): *(Optional `string`)*<a name="attr-policy_bindings-condition-description"></a>
+
+      An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+
+#### Module Configuration
+
+- [**`module_enabled`**](#var-module_enabled): *(Optional `bool`)*<a name="var-module_enabled"></a>
+
+  Specifies whether resources in the module will be created.
+
+  Default is `true`.
+
+- [**`module_depends_on`**](#var-module_depends_on): *(Optional `list(dependency)`)*<a name="var-module_depends_on"></a>
+
+  A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.
+
+  Example:
+
+  ```hcl
+  module_depends_on = [
+    google_network.network
+  ]
+  ```
+
+## Module Outputs
+
+The following attributes are exported in the outputs of the module:
+
+- [**`iam`**](#output-iam): *(`object(iam)`)*<a name="output-iam"></a>
+
+  All attributes of the created `google_cloud_tasks_queue_iam_binding` or `google_cloud_tasks_queue_iam_member` or `google_cloud_tasks_queue_iam_policy` resource according to the mode.
+
+## External Documentation
+
+### Google Documentation
+
+- https://cloud.google.com/tasks/docs/reference-access-control
+
+### Terraform Google Provider Documentation:
+
+- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_tasks_queue_iam
+
+## Module Versioning
+
+This Module follows the principles of [Semantic Versioning (SemVer)].
+
+Given a version number `MAJOR.MINOR.PATCH`, we increment the:
+
+1. `MAJOR` version when we make incompatible changes,
+2. `MINOR` version when we add functionality in a backwards compatible manner, and
+3. `PATCH` version when we make backwards compatible bug fixes.
+
+### Backward compatibility in `0.0.z` and `0.y.z` version
+
+- Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased. (Initial development)
+- Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased. (Pre-release)
+
+## About Mineiros
+
+[Mineiros][homepage] is a remote-first company headquartered in Berlin, Germany
+that solves development, automation and security challenges in cloud infrastructure.
+
+Our vision is to massively reduce time and overhead for teams to manage and
+deploy production-grade and secure cloud infrastructure.
+
+We offer commercial support for all of our modules and encourage you to reach out
+if you have any questions or need help. Feel free to email us at [hello@mineiros.io] or join our
+[Community Discord server][discord].
+
+## Reporting Issues
+
+We use GitHub [Issues] to track community reported issues and missing features.
+
+## Contributing
+
+Contributions are always encouraged and welcome! For the process of accepting changes, we use
+[Pull Requests]. If you'd like more information, please see our [Contribution Guidelines].
+
+## Makefile Targets
+
+This repository comes with a handy [Makefile].
+Run `make help` to see details on each available target.
+
+## License
+
+[![license][badge-license]][apache20]
+
+This module is licensed under the Apache License Version 2.0, January 2004.
+Please see [LICENSE] for full details.
+
+Copyright &copy; 2020-2023 [Mineiros GmbH][homepage]
+
+
+<!-- References -->
+
+[homepage]: https://mineiros.io/?ref=terraform-google-iam
+[hello@mineiros.io]: mailto:hello@mineiros.io
+[badge-build]: https://github.com/mineiros-io/terraform-google-iam/workflows/Tests/badge.svg
+[badge-semver]: https://img.shields.io/github/v/tag/mineiros-io/terraform-google-iam.svg?label=latest&sort=semver
+[badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
+[badge-terraform]: https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform
+[badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
+[build-status]: https://github.com/mineiros-io/terraform-google-iam/actions
+[releases-github]: https://github.com/mineiros-io/terraform-google-iam/releases
+[releases-terraform]: https://github.com/hashicorp/terraform/releases
+[badge-tf-gcp]: https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform
+[releases-google-provider]: https://github.com/terraform-providers/terraform-provider-google/releases
+[apache20]: https://opensource.org/licenses/Apache-2.0
+[slack]: https://mineiros.io/slack
+[discord]: https://terramate.io/discord
+[terraform]: https://www.terraform.io
+[gcp]: https://cloud.google.com/
+[semantic versioning (semver)]: https://semver.org/
+[variables.tf]: https://github.com/mineiros-io/terraform-google-iam/blob/main/modules/google/google_cloud_tasks_queue_iam/variables.tf
+[issues]: https://github.com/mineiros-io/terraform-google-iam/issues
+[license]: https://github.com/mineiros-io/terraform-google-iam/blob/main/LICENSE
+[makefile]: https://github.com/mineiros-io/terraform-google-iam/blob/main/Makefile
+[pull requests]: https://github.com/mineiros-io/terraform-google-iam/pulls
+[contribution guidelines]: https://github.com/mineiros-io/terraform-google-iam/blob/main/CONTRIBUTING.md

--- a/modules/google/google_cloud_tasks_queue_iam/README.tfdoc.hcl
+++ b/modules/google/google_cloud_tasks_queue_iam/README.tfdoc.hcl
@@ -1,0 +1,408 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+header {
+  image = "https://raw.githubusercontent.com/mineiros-io/brand/851a473f65dd7d857a9311ca255c6e2763c72afe/mineiros-logo.svg"
+  url   = "https://mineiros.io/?ref=terraform-google-iam"
+  badge "build" {
+    image = "https://github.com/mineiros-io/terraform-google-iam/workflows/Tests/badge.svg"
+    text  = "Build Status"
+    url   = "https://github.com/mineiros-io/terraform-google-iam/actions"
+  }
+  badge "semver" {
+    image = "https://img.shields.io/github/v/tag/mineiros-io/terraform-google-iam.svg?label=latest&sort=semver"
+    text  = "GitHub tag (latest SemVer)"
+    url   = "https://github.com/mineiros-io/terraform-google-iam/releases"
+  }
+  badge "terraform" {
+    image = "https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform"
+    text  = "Terraform Version"
+    url   = "https://github.com/hashicorp/terraform/releases"
+  }
+  badge "terraform-google-provider" {
+    image = "https://img.shields.io/badge/google-4-1A73E8.svg?logo=terraform"
+    text  = "Google Provider Version"
+    url   = "https://github.com/terraform-providers/terraform-provider-google/releases"
+  }
+  badge "discord" {
+    image = "https://img.shields.io/badge/Discord-Terramate-7289d9.svg?logo=discord"
+    text  = "Join Discord"
+    url   = "https://terramate.io/discord"
+  }
+}
+section {
+  content = <<-EOT
+A [Terraform](https://www.terraform.io) module to create a [Google Cloud Tasks IAM](https://cloud.google.com/tasks/docs/reference-access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
+
+**_This module supports Terraform version 1
+and is compatible with the Terraform Google Provider version 4._**
+
+This module is part of our Infrastructure as Code (IaC) framework
+that enables our users and customers to easily deploy and manage reusable,
+secure, and production-grade cloud infrastructure.
+EOT
+
+  title = "Google Cloud Tasks IAM Terraform Module"
+  toc   = true
+  section {
+    content = <<-EOT
+This module implements the following Terraform resources:
+
+- `google_cloud_tasks_queue_iam_binding`
+- `google_cloud_tasks_queue_iam_member`
+- `google_cloud_tasks_queue_iam_policy`
+EOT
+
+    title = "Module Features"
+  }
+  section {
+    content = <<-EOT
+Most common usage of the module:
+
+```hcl
+module "google_cloud_tasks_queue_iam" {
+  source = "github.com/mineiros-io/terraform-google-iam//modules/google/google_cloud_tasks_queue_iam?ref=v0.1.2"
+
+  name  = google_cloud_tasks_queue.default.name
+  location = google_cloud_tasks_queue.default.location
+  role     = "roles/cloudtasks.taskRunner"
+  members  = ["user:admin@example.com"]
+}
+```
+EOT
+
+    title = "Getting Started"
+  }
+  section {
+    content = <<-EOT
+See [variables.tf] for details.
+EOT
+
+    title = "Module Argument Reference"
+    section {
+      title = "Top-level Arguments"
+      section {
+        title = "Main Resource Configuration"
+        variable "name" {
+          description = <<-EOT
+Name of Cloud Tasks Queue the IAM is applied to.
+EOT
+
+          required = true
+          type     = string
+        }
+        variable "location" {
+          description = "The location used to find the parent resource to bind the IAM policy to"
+          required    = true
+          type        = string
+        }
+        variable "members" {
+          default = [
+          ]
+          description = <<-EOT
+Identities that will be granted the privilege in role. Each entry can have one of the following values:
+`allUsers`, `allAuthenticatedUsers`, `user:{emailid}`, `serviceAccount:{emailid}`, `group:{emailid}`, `domain:{domain}`, `projectOwner:{projectid}`, `projectEditor:{projectid}`, `projectViewer:{projectid}`, `computed:{identifier}`.
+EOT
+
+          type = set(string)
+        }
+        variable "computed_members_map" {
+          default     = {}
+          description = <<-EOT
+A map of members to replace in 'var.members' or in members of 'policy_bindings' to handle terraform computed values.
+EOT
+
+          type = map(string)
+        }
+        variable "role" {
+          description = <<-EOT
+The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`. Omit if `policy_bindings` is set.
+EOT
+
+          type = string
+        }
+        variable "project" {
+          description = <<-EOT
+The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used.
+EOT
+
+          type = string
+        }
+        variable "authoritative" {
+          default     = true
+          description = <<-EOT
+Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role.
+EOT
+
+          type = bool
+        }
+        variable "policy_bindings" {
+          description = <<-EOT
+A list of IAM policy bindings. Cannot be used at the same time as `role`.
+EOT
+
+          readme_example = <<-EOT
+policy_bindings = [{
+  role    = "roles/cloudtasks.taskRunner"
+  members = ["user:admin@example.com"]
+}]
+EOT
+
+          type = list(policy_binding)
+          attribute "role" {
+            description = <<-EOT
+The role that should be applied.
+EOT
+
+            required = true
+            type     = string
+          }
+          attribute "members" {
+            default     = var.members
+            description = <<-EOT
+Identities that will be granted the privilege in `role`.
+EOT
+
+            type = set(string)
+          }
+          attribute "condition" {
+            description = <<-EOT
+An IAM Condition for a given binding.
+EOT
+
+            readme_example = <<-EOT
+condition = {
+  expression = "request.time < timestamp(\"2024-01-01T00:00:00Z\")"
+  title      = "expires_after_2023_12_31"
+}
+EOT
+
+            type = object(condition)
+            attribute "expression" {
+              description = <<-EOT
+Textual representation of an expression in Common Expression Language syntax.
+EOT
+
+              required = true
+              type     = string
+            }
+            attribute "title" {
+              description = <<-EOT
+A title for the expression, i.e. a short string describing its purpose.
+EOT
+
+              required = true
+              type     = string
+            }
+            attribute "description" {
+              description = <<-EOT
+An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+EOT
+
+              type = string
+            }
+          }
+        }
+      }
+      section {
+        title = "Module Configuration"
+        variable "module_enabled" {
+          default     = true
+          description = <<-EOT
+Specifies whether resources in the module will be created.
+EOT
+
+          type = bool
+        }
+        variable "module_depends_on" {
+          description = <<-EOT
+A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.
+EOT
+
+          readme_example = <<-EOT
+module_depends_on = [
+  google_network.network
+]
+EOT
+
+          type = list(dependency)
+        }
+      }
+    }
+  }
+  section {
+    content = <<-EOT
+The following attributes are exported in the outputs of the module:
+EOT
+
+    title = "Module Outputs"
+    output "iam" {
+      description = <<-EOT
+All attributes of the created `google_cloud_tasks_queue_iam_binding` or `google_cloud_tasks_queue_iam_member` or `google_cloud_tasks_queue_iam_policy` resource according to the mode.
+EOT
+
+      type = object(iam)
+    }
+  }
+  section {
+    title = "External Documentation"
+    section {
+      content = <<-EOT
+- https://cloud.google.com/tasks/docs/reference-access-control
+EOT
+
+      title = "Google Documentation"
+    }
+    section {
+      content = <<-EOT
+- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_tasks_queue_iam
+EOT
+
+      title = "Terraform Google Provider Documentation:"
+    }
+  }
+  section {
+    content = <<-EOT
+This Module follows the principles of [Semantic Versioning (SemVer)].
+
+Given a version number `MAJOR.MINOR.PATCH`, we increment the:
+
+1. `MAJOR` version when we make incompatible changes,
+2. `MINOR` version when we add functionality in a backwards compatible manner, and
+3. `PATCH` version when we make backwards compatible bug fixes.
+EOT
+
+    title = "Module Versioning"
+    section {
+      content = <<-EOT
+- Backward compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased. (Initial development)
+- Backward compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased. (Pre-release)
+EOT
+
+      title = "Backward compatibility in `0.0.z` and `0.y.z` version"
+    }
+  }
+  section {
+    content = <<-EOT
+[Mineiros][homepage] is a remote-first company headquartered in Berlin, Germany
+that solves development, automation and security challenges in cloud infrastructure.
+
+Our vision is to massively reduce time and overhead for teams to manage and
+deploy production-grade and secure cloud infrastructure.
+
+We offer commercial support for all of our modules and encourage you to reach out
+if you have any questions or need help. Feel free to email us at [hello@mineiros.io] or join our
+[Community Discord server][discord].
+EOT
+
+    title = "About Mineiros"
+  }
+  section {
+    content = <<-EOT
+We use GitHub [Issues] to track community reported issues and missing features.
+EOT
+
+    title = "Reporting Issues"
+  }
+  section {
+    content = <<-EOT
+Contributions are always encouraged and welcome! For the process of accepting changes, we use
+[Pull Requests]. If you'd like more information, please see our [Contribution Guidelines].
+EOT
+
+    title = "Contributing"
+  }
+  section {
+    content = <<-EOT
+This repository comes with a handy [Makefile].
+Run `make help` to see details on each available target.
+EOT
+
+    title = "Makefile Targets"
+  }
+  section {
+    content = <<-EOT
+[![license][badge-license]][apache20]
+
+This module is licensed under the Apache License Version 2.0, January 2004.
+Please see [LICENSE] for full details.
+
+Copyright &copy; 2020-2023 [Mineiros GmbH][homepage]
+EOT
+
+    title = "License"
+  }
+}
+references {
+  ref "homepage" {
+    value = "https://mineiros.io/?ref=terraform-google-iam"
+  }
+  ref "hello@mineiros.io" {
+    value = "mailto:hello@mineiros.io"
+  }
+  ref "badge-build" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/workflows/Tests/badge.svg"
+  }
+  ref "badge-semver" {
+    value = "https://img.shields.io/github/v/tag/mineiros-io/terraform-google-iam.svg?label=latest&sort=semver"
+  }
+  ref "badge-license" {
+    value = "https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg"
+  }
+  ref "badge-terraform" {
+    value = "https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform"
+  }
+  ref "badge-slack" {
+    value = "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack"
+  }
+  ref "build-status" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/actions"
+  }
+  ref "releases-github" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/releases"
+  }
+  ref "releases-terraform" {
+    value = "https://github.com/hashicorp/terraform/releases"
+  }
+  ref "badge-tf-gcp" {
+    value = "https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform"
+  }
+  ref "releases-google-provider" {
+    value = "https://github.com/terraform-providers/terraform-provider-google/releases"
+  }
+  ref "apache20" {
+    value = "https://opensource.org/licenses/Apache-2.0"
+  }
+  ref "slack" {
+    value = "https://mineiros.io/slack"
+  }
+  ref "discord" {
+    value = "https://terramate.io/discord"
+  }
+  ref "terraform" {
+    value = "https://www.terraform.io"
+  }
+  ref "gcp" {
+    value = "https://cloud.google.com/"
+  }
+  ref "semantic versioning (semver)" {
+    value = "https://semver.org/"
+  }
+  ref "variables.tf" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/blob/main/modules/google/google_cloud_tasks_queue_iam/variables.tf"
+  }
+  ref "issues" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/issues"
+  }
+  ref "license" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/blob/main/LICENSE"
+  }
+  ref "makefile" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/blob/main/Makefile"
+  }
+  ref "pull requests" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/pulls"
+  }
+  ref "contribution guidelines" {
+    value = "https://github.com/mineiros-io/terraform-google-iam/blob/main/CONTRIBUTING.md"
+  }
+}

--- a/modules/google/google_cloud_tasks_queue_iam/main.tf
+++ b/modules/google/google_cloud_tasks_queue_iam/main.tf
@@ -1,0 +1,60 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+resource "google_cloud_tasks_queue_iam_binding" "binding" {
+  name     = var.name
+  location = var.location
+  count    = var.module_enabled && var.policy_bindings == null && var.authoritative ? 1 : 0
+  depends_on = [
+    var.module_depends_on,
+  ]
+  members  = [for m in var.members : try(var.computed_members_map[regex("^computed:(.*)", m)[0]], m)]
+  project  = var.project
+  provider = google
+  role     = var.role
+}
+resource "google_cloud_tasks_queue_iam_member" "member" {
+  name     = var.name
+  location = var.location
+  depends_on = [
+    var.module_depends_on,
+  ]
+  for_each = var.module_enabled && var.policy_bindings == null && var.authoritative == false ? var.members : [
+  ]
+  member   = try(var.computed_members_map[regex("^computed:(.*)", each.value)[0]], each.value)
+  project  = var.project
+  provider = google
+  role     = var.role
+}
+resource "google_cloud_tasks_queue_iam_policy" "policy" {
+  name     = var.name
+  location = var.location
+  count    = var.module_enabled && var.policy_bindings != null ? 1 : 0
+  depends_on = [
+    var.module_depends_on,
+  ]
+  policy_data = try(data.google_iam_policy.policy[0].policy_data, null)
+  project     = var.project
+  provider    = google
+}
+data "google_iam_policy" "policy" {
+  count    = var.module_enabled && var.policy_bindings != null ? 1 : 0
+  provider = google
+  dynamic "binding" {
+    for_each = var.policy_bindings
+    content {
+      members = [for m in binding.value.members : try(var.computed_members_map[regex("^computed:(.*)", m)[0]], m)]
+      role    = binding.value.role
+      dynamic "condition" {
+        for_each = try([
+          binding.value.condition,
+          ], [
+        ])
+        content {
+          description = try(condition.value.description, null)
+          expression  = condition.value.expression
+          title       = condition.value.title
+        }
+      }
+    }
+  }
+}

--- a/modules/google/google_cloud_tasks_queue_iam/outputs.tf
+++ b/modules/google/google_cloud_tasks_queue_iam/outputs.tf
@@ -1,0 +1,17 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+locals {
+  binding = one(google_cloud_tasks_queue_iam_binding.binding)
+  iam_output = [
+    local.binding,
+    local.member,
+    local.policy,
+  ]
+  iam_output_index = var.policy_bindings != null ? 2 : var.authoritative ? 0 : 1
+  member           = google_cloud_tasks_queue_iam_member.member
+  policy           = one(google_cloud_tasks_queue_iam_policy.policy)
+}
+output "iam" {
+  description = "All attributes of the created 'iam_binding' or 'iam_member' or 'iam_policy' resource according to the mode."
+  value       = local.iam_output[local.iam_output_index]
+}

--- a/modules/google/google_cloud_tasks_queue_iam/stack.tm.hcl
+++ b/modules/google/google_cloud_tasks_queue_iam/stack.tm.hcl
@@ -1,0 +1,21 @@
+stack {
+  name        = "google_cloud_tasks_queue_iam"
+  description = "Google Cloud Tasks IAM Terraform Module"
+  id          = "782050be-255c-4aa6-9144-57a003cc4846"
+}
+
+globals {
+  minimum_provider_version = "4.28"
+  is_regional              = true
+  resource_parent = {
+    variable      = "name"
+    resource_name = "google_cloud_tasks_queue"
+    description   = "Name of Cloud Tasks Queue the IAM is applied to"
+  }
+  documentation = {
+    service_name      = "Google Cloud Tasks"
+    google_docs_url   = "https://cloud.google.com/tasks/docs/reference-access-control"
+    provider_docs_url = "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_tasks_queue_iam"
+    example_role      = "cloudtasks.taskRunner"
+  }
+}

--- a/modules/google/google_cloud_tasks_queue_iam/tests/unit-complete/main.tf
+++ b/modules/google/google_cloud_tasks_queue_iam/tests/unit-complete/main.tf
@@ -1,0 +1,91 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+terraform {
+  required_version = "~> 1.0, != 1.1.0, != 1.1.1"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.28"
+    }
+  }
+}
+module "test-sa" {
+  account_id = "service-account-id-complete"
+  project    = "my-project"
+  source     = "github.com/mineiros-io/terraform-google-service-account?ref=v0.1.1"
+}
+module "test0" {
+  name     = "name-complete0"
+  location = "europe-west3"
+  computed_members_map = {
+    myserviceaccount = "serviceAccount:${module.test-sa.service_account.email}"
+  }
+  members = [
+    "user:member@example.com",
+    "computed:myserviceaccount",
+  ]
+  project = "my-project"
+  role    = "roles/viewer"
+  source  = "../.."
+}
+module "test1" {
+  name          = "name-complete1"
+  location      = "europe-west3"
+  authoritative = false
+  computed_members_map = {
+    myserviceaccount = "serviceAccount:${module.test-sa.service_account.email}"
+  }
+  members = [
+    "user:member@example.com",
+    "computed:myserviceaccount",
+  ]
+  project = "my-project"
+  role    = "roles/viewer"
+  source  = "../.."
+}
+module "test2" {
+  name     = "name-complete2"
+  location = "europe-west3"
+  computed_members_map = {
+    myserviceaccount = "serviceAccount:${module.test-sa.service_account.email}"
+  }
+  policy_bindings = [
+    {
+      role = "roles/viewer"
+      members = [
+        "user:member@example.com",
+        "computed:myserviceaccount",
+      ]
+    },
+    {
+      role = "roles/browser"
+      members = [
+        "user:member@example.com",
+      ]
+    },
+  ]
+  project = "my-project"
+  source  = "../.."
+}
+module "test3" {
+  name     = "name-complete3"
+  location = "europe-west3"
+  computed_members_map = {
+    myserviceaccount = "serviceAccount:${module.test-sa.service_account.email}"
+  }
+  policy_bindings = [
+    {
+      role = "roles/viewer"
+      members = [
+        "user:member@example.com",
+        "computed:myserviceaccount",
+      ]
+      condition = {
+        expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
+        title      = "expires_after_2021_12_31"
+      }
+    },
+  ]
+  project = "my-project"
+  source  = "../.."
+}

--- a/modules/google/google_cloud_tasks_queue_iam/tests/unit-disabled/main.tf
+++ b/modules/google/google_cloud_tasks_queue_iam/tests/unit-disabled/main.tf
@@ -1,0 +1,53 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+terraform {
+  required_version = "~> 1.0, != 1.1.0, != 1.1.1"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.28"
+    }
+  }
+}
+module "test0" {
+  name     = "name-disabled0"
+  location = "europe-west3"
+  members = [
+    "user:member@example.com",
+  ]
+  module_enabled = false
+  project        = "my-project"
+  role           = "roles/viewer"
+  source         = "../.."
+}
+module "test1" {
+  name          = "name-disabled1"
+  location      = "europe-west3"
+  authoritative = false
+  members = [
+    "user:member@example.com",
+  ]
+  module_enabled = false
+  project        = "my-project"
+  role           = "roles/viewer"
+  source         = "../.."
+}
+module "test2" {
+  name     = "name-disabled2"
+  location = "europe-west3"
+  members = [
+    "user:member@example.com",
+  ]
+  module_enabled = false
+  policy_bindings = [
+    {
+      role = "roles/viewer"
+      members = [
+        "user:member@example.com",
+      ]
+    },
+  ]
+  project = "my-project"
+  role    = "roles/viewer"
+  source  = "../.."
+}

--- a/modules/google/google_cloud_tasks_queue_iam/tests/unit-minimal/main.tf
+++ b/modules/google/google_cloud_tasks_queue_iam/tests/unit-minimal/main.tf
@@ -1,0 +1,50 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+terraform {
+  required_version = "~> 1.0, != 1.1.0, != 1.1.1"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.28"
+    }
+  }
+}
+module "test0" {
+  name     = "name-minimal0"
+  location = "europe-west3"
+  members = [
+    "user:member@example.com",
+  ]
+  project = "my-project"
+  role    = "roles/viewer"
+  source  = "../.."
+}
+module "test1" {
+  name          = "name-minimal1"
+  location      = "europe-west3"
+  authoritative = false
+  members = [
+    "user:member@example.com",
+  ]
+  project = "my-project"
+  role    = "roles/viewer"
+  source  = "../.."
+}
+module "test2" {
+  name     = "name-minimal2"
+  location = "europe-west3"
+  members = [
+    "user:member@example.com",
+  ]
+  policy_bindings = [
+    {
+      role = "roles/viewer"
+      members = [
+        "user:member@example.com",
+      ]
+    },
+  ]
+  project = "my-project"
+  role    = "roles/viewer"
+  source  = "../.."
+}

--- a/modules/google/google_cloud_tasks_queue_iam/variables.tf
+++ b/modules/google/google_cloud_tasks_queue_iam/variables.tf
@@ -1,0 +1,60 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+variable "name" {
+  description = "(Required) Name of Cloud Tasks Queue the IAM is applied to"
+  type        = string
+}
+variable "location" {
+  description = "(Required) The location used to find the parent resource to bind the IAM policy to"
+  type        = string
+}
+variable "project" {
+  default     = null
+  description = "The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used."
+  type        = string
+}
+variable "members" {
+  default = [
+  ]
+  description = "(Optional) Identities that will be granted the privilege in role."
+  type        = set(string)
+  validation {
+    condition     = alltrue([for m in var.members : can(regex("^allUsers$|^allAuthenticatedUsers$|^user:|^serviceAccount:|^group:|^domain:|^projectOwner:|^projectEditor:|^projectViewer:|^computed:", m))])
+    error_message = "The value must be set of strings where each entry is a valid principal type identified with `allUsers`, `allAuthenticatedUsers`, `user:{emailid}`, `serviceAccount:{emailid}`, `group:{emailid}`, `domain:{domain}`, `projectOwner:{projectid}`, `projectEditor:{projectid}`, `projectViewer:{projectid}`, `computed:{identifier}`"
+  }
+}
+variable "computed_members_map" {
+  default     = {}
+  description = "(Optional) A map of members to replace in 'var.members' or in members of 'policy_bindings' to handle terraform computed values."
+  type        = map(string)
+  validation {
+    condition     = alltrue([for k, m in var.computed_members_map : can(regex("^allUsers$|^allAuthenticatedUsers$|^user:|^serviceAccount:|^group:|^domain:|^projectOwner:|^projectEditor:|^projectViewer:", m))])
+    error_message = "The value must be set of strings where each entry is a valid principal type identified with `allUsers`, `allAuthenticatedUsers`, `user:{emailid}`, `serviceAccount:{emailid}`, `group:{emailid}`, `domain:{domain}`, `projectOwner:{projectid}`, `projectEditor:{projectid}`, `projectViewer:{projectid}`"
+  }
+}
+variable "role" {
+  default     = null
+  description = "(Optional) The IAM role to add the members to. Note that custom roles must be of the format '[projects|organizations]/{parent-name}/roles/{role-name}'."
+  type        = string
+}
+variable "authoritative" {
+  default     = true
+  description = "(Optional) Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role."
+  type        = bool
+}
+variable "policy_bindings" {
+  default     = null
+  description = "(Optional) A list of IAM policy bindings."
+  type        = any
+}
+variable "module_enabled" {
+  default     = true
+  description = "(Optional) Whether to create resources within the module or not."
+  type        = bool
+}
+variable "module_depends_on" {
+  default = [
+  ]
+  description = "(Optional) A list of external resources the module depends_on."
+  type        = any
+}

--- a/modules/google/google_cloud_tasks_queue_iam/versions.tf
+++ b/modules/google/google_cloud_tasks_queue_iam/versions.tf
@@ -1,0 +1,11 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+terraform {
+  required_version = "~> 1.0, != 1.1.0, != 1.1.1"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.28"
+    }
+  }
+}

--- a/terramate.tm.hcl
+++ b/terramate.tm.hcl
@@ -1,13 +1,13 @@
 terramate {
-  required_version                   = "~> 0.2.16"
+  required_version                   = "~> 0.4.0"
   required_version_allow_prereleases = true
 
   config {
     run {
       env {
-        TF_PLUGIN_CACHE_DIR = "${terramate.root.path.fs.absolute}/.tf_plugin_cache_dir"
-        TM_STACK_PATH       = terramate.stack.path.relative
-        TM_STACK_TO_ROOT    = terramate.stack.path.to_root
+        # TF_PLUGIN_CACHE_DIR = "${terramate.root.path.fs.absolute}/.tf_plugin_cache_dir"
+        TM_STACK_PATH    = terramate.stack.path.relative
+        TM_STACK_TO_ROOT = terramate.stack.path.to_root
       }
     }
   }


### PR DESCRIPTION
### Changed
- Upgraded tool versions
### Added
- Generated the google_cloud_tasks_queue_iam module
### Fixed
- Removed the Terraform plugin cache that caused concurrent `terraform init` to fail